### PR TITLE
잘못된 깃허브 페이지 URL 해결

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ B2G 공모사업 자동화 관리 웹서비스 - 나라장터 공고 통합 관�
 2. **package.json 수정**
    - `homepage` 필드를 실제 GitHub 사용자명과 저장소명으로 수정:
    ```json
-   "homepage": "https://[YOUR_GITHUB_USERNAME].github.io/[YOUR_REPOSITORY_NAME]"
+   "homepage": "https://hersouls.github.io/B2G_v1.0"
    ```
 
 3. **자동 배포**

--- a/react-tailwind-app/package.json
+++ b/react-tailwind-app/package.json
@@ -2,7 +2,7 @@
   "name": "react-tailwind-app",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://[YOUR_GITHUB_USERNAME].github.io/[YOUR_REPOSITORY_NAME]",
+  "homepage": "https://hersouls.github.io/B2G_v1.0",
   "dependencies": {
     "@headlessui/react": "^2.2.4",
     "@heroicons/react": "^2.2.0",


### PR DESCRIPTION
Fix 'Invalid URL' error by replacing GitHub Pages URL placeholders with actual repository URL.

The `TypeError [ERR_INVALID_URL]` occurred because `homepage` and other URL references in `package.json` and `README.md` were still using placeholder values (`https://[YOUR_GITHUB_USERNAME].github.io/[YOUR_REPOSITORY_NAME]/`) instead of the correct GitHub Pages URL. This PR updates these placeholders to `https://hersouls.github.io/B2G_v1.0/`, resolving the build/deployment issue.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-83f9df21-dabd-4de1-b2cc-7144b0830e43) · [Cursor](https://cursor.com/background-agent?bcId=bc-83f9df21-dabd-4de1-b2cc-7144b0830e43)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)