### PR TITLE
InputProps size 타입 충돌 해결

### DIFF
--- a/react-tailwind-app/src/components/Input.tsx
+++ b/react-tailwind-app/src/components/Input.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import clsx from 'clsx';
 
-interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
   label?: string;
   error?: string;
   helperText?: string;
@@ -104,7 +104,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(({
 Input.displayName = 'Input';
 
 // Textarea Component
-interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+interface TextareaProps extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'size'> {
   label?: string;
   error?: string;
   helperText?: string;


### PR DESCRIPTION
Fix TypeScript type collision for `size` prop in `InputProps` and `TextareaProps`.

The original interfaces extended native HTML attributes, which include a `size` prop of type `string | number`. A custom `size` prop was also defined as `'sm' | 'md' | 'lg'`, causing a type conflict. By using `Omit<..., 'size'>`, the native `size` prop is excluded, allowing only the custom `size` prop to be used, resolving the TypeScript error.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-48a6021c-228e-4955-9231-ad9732f8afcd) · [Cursor](https://cursor.com/background-agent?bcId=bc-48a6021c-228e-4955-9231-ad9732f8afcd)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)