### PR TITLE
뱃지 색상 함수 수정

### DIFF
--- a/react-tailwind-app/src/components/Notification/NotificationDetail.tsx
+++ b/react-tailwind-app/src/components/Notification/NotificationDetail.tsx
@@ -75,13 +75,13 @@ export const NotificationDetail: React.FC<NotificationDetailProps> = ({
       case 'unread':
         return 'primary';
       case 'read':
-        return 'default';
+        return 'gray';
       case 'important':
         return 'warning';
       case 'completed':
         return 'success';
       default:
-        return 'default';
+        return 'gray';
     }
   };
 

--- a/react-tailwind-app/src/components/Notification/NotificationList.tsx
+++ b/react-tailwind-app/src/components/Notification/NotificationList.tsx
@@ -137,13 +137,13 @@ export const NotificationList: React.FC<NotificationListProps> = ({
       case 'unread':
         return 'primary';
       case 'read':
-        return 'default';
+        return 'gray';
       case 'important':
         return 'warning';
       case 'completed':
         return 'success';
       default:
-        return 'default';
+        return 'gray';
     }
   };
 


### PR DESCRIPTION
Change `getStatusColor` return value from 'default' to 'gray' to resolve Badge component variant error.

The `Badge` component's `variant` prop does not accept `'default'`, leading to an error. This change ensures `getStatusColor` returns only accepted variant values.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-cd0c84b8-b3e9-47c4-8417-9c97ed5060f4) · [Cursor](https://cursor.com/background-agent?bcId=bc-cd0c84b8-b3e9-47c4-8417-9c97ed5060f4)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)