### PR TITLE
뱃지 색상 함수 값 조정

### DIFF
--- a/react-tailwind-app/src/components/Personal/ProfileSection.tsx
+++ b/react-tailwind-app/src/components/Personal/ProfileSection.tsx
@@ -101,8 +101,8 @@ export const ProfileSection: React.FC = () => {
     switch (role) {
       case 'admin': return 'danger';
       case 'user': return 'primary';
-      case 'guest': return 'default';
-      default: return 'default';
+      case 'guest': return 'gray';
+      default: return 'secondary';
     }
   };
 


### PR DESCRIPTION
Ensure `getRoleColor` returns only supported Badge variant values.

The `getRoleColor` function previously returned 'default' for certain roles, which is not a valid variant for the Badge component. This change updates the function to return 'gray' for the 'guest' role and 'secondary' for the default case, resolving the incompatibility.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-bb3e86f9-f1c1-47c6-bbf6-fda06541d8a6) · [Cursor](https://cursor.com/background-agent?bcId=bc-bb3e86f9-f1c1-47c6-bbf6-fda06541d8a6)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)