### PR TITLE
React cloneElement 타입 정의

### DIFF
--- a/react-tailwind-app/src/components/Table.tsx
+++ b/react-tailwind-app/src/components/Table.tsx
@@ -211,12 +211,13 @@ const Table = <T extends Record<string, any> = any>({
         )}>
           {React.Children.map(children, (child, index) => {
             if (React.isValidElement(child)) {
+              // TableComponentProps를 구현하는 컴포넌트에만 해당 props 전달
               return React.cloneElement(child, {
                 striped,
                 hover,
                 compact,
                 index
-              });
+              } as React.ComponentProps<any>);
             }
             return child;
           })}
@@ -302,13 +303,17 @@ export const TableHeaderCell: React.FC<TableHeaderCellProps> = ({
   );
 };
 
-interface TableRowProps {
-  children: React.ReactNode;
-  className?: string;
+// 테이블 컴포넌트들이 공통으로 받을 수 있는 props
+interface TableComponentProps {
   striped?: boolean;
   hover?: boolean;
   compact?: boolean;
   index?: number;
+}
+
+interface TableRowProps extends TableComponentProps {
+  children: React.ReactNode;
+  className?: string;
   onClick?: () => void;
   selected?: boolean;
 }
@@ -340,18 +345,20 @@ export const TableRow: React.FC<TableRowProps> = ({
   );
 };
 
-interface TableCellProps {
+interface TableCellProps extends TableComponentProps {
   children: React.ReactNode;
   className?: string;
   align?: 'left' | 'center' | 'right';
-  compact?: boolean;
 }
 
 export const TableCell: React.FC<TableCellProps> = ({
   children,
   className,
   align = 'left',
-  compact = false
+  compact = false,
+  striped,
+  hover,
+  index
 }) => {
   const alignClasses = {
     left: 'text-left',


### PR DESCRIPTION
Unify table component props and add type assertion to resolve `cloneElement` TypeScript errors.

The `Table` component uses `React.cloneElement` to pass common props (`striped`, `hover`, `compact`, `index`) to its children. Previously, `TableCell` was not typed to receive all these props, causing TypeScript errors. This PR introduces a shared `TableComponentProps` interface, extends `TableRowProps` and `TableCellProps` with it, and explicitly passes the props to `TableCell` to ensure type compatibility and resolve the errors. It also adds a type assertion for `cloneElement` for broader compatibility.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-c854bf36-a294-4ee7-955b-b58348de5ca4) · [Cursor](https://cursor.com/background-agent?bcId=bc-c854bf36-a294-4ee7-955b-b58348de5ca4)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)