### PR TITLE
CardHeader children prop 필수 오류 해결

### DIFF
--- a/react-tailwind-app/src/components/Card.tsx
+++ b/react-tailwind-app/src/components/Card.tsx
@@ -66,7 +66,7 @@ const Card: React.FC<CardProps> = ({
 };
 
 interface CardHeaderProps {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   className?: string;
   title?: string;
   subtitle?: string;


### PR DESCRIPTION
Make `children` prop in `CardHeaderProps` optional to resolve type errors when `CardHeader` is used without children.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-08cf948d-8bb7-4fdc-ab3e-8038a4a05ed1) · [Cursor](https://cursor.com/background-agent?bcId=bc-08cf948d-8bb7-4fdc-ab3e-8038a4a05ed1)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)