### PR TITLE
버튼 variant 속성 허용값으로 변경

### DIFF
--- a/react-tailwind-app/README_UI_COMPONENTS.md
+++ b/react-tailwind-app/README_UI_COMPONENTS.md
@@ -69,7 +69,7 @@ interface ButtonProps {
 <Button variant="primary">Primary</Button>
 <Button variant="secondary">Secondary</Button>
 <Button variant="outline">Outline</Button>
-<Button variant="success">Success</Button>
+<Button variant="primary" className="bg-green-600 hover:bg-green-700">Success</Button>
 <Button variant="danger">Danger</Button>
 <Button variant="ghost">Ghost</Button>
 

--- a/react-tailwind-app/src/components/UIComponents.tsx
+++ b/react-tailwind-app/src/components/UIComponents.tsx
@@ -166,7 +166,7 @@ const UIComponents: React.FC = () => {
                   <Button variant="primary">Primary</Button>
                   <Button variant="secondary">Secondary</Button>
                   <Button variant="outline">Outline</Button>
-                  <Button variant="success">Success</Button>
+                  <Button variant="primary" className="bg-green-600 hover:bg-green-700">Success</Button>
                   <Button variant="danger">Danger</Button>
                   <Button variant="ghost">Ghost</Button>
                 </div>


### PR DESCRIPTION
Update Button component usage to remove unsupported 'success' variant.

The `Button` component does not support a `success` variant. Instances using `variant="success"` have been updated to `variant="primary"` and custom Tailwind CSS classes (`bg-green-600 hover:bg-green-700`) have been added to maintain the green appearance.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-c139673a-d863-42a8-a863-c6b50e02b953) · [Cursor](https://cursor.com/background-agent?bcId=bc-c139673a-d863-42a8-a863-c6b50e02b953)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)