### PR TITLE
버튼 size prop 타입 오류 해결

### DIFF
--- a/react-tailwind-app/src/components/Button.tsx
+++ b/react-tailwind-app/src/components/Button.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'outline' | 'ghost' | 'danger';
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'sm' | 'md' | 'lg' | 'xl';
   loading?: boolean;
   icon?: React.ReactNode;
   iconPosition?: 'left' | 'right';
@@ -36,6 +36,7 @@ const Button: React.FC<ButtonProps> = ({
     sm: 'px-3 py-1.5 text-body3',
     md: 'px-4 py-2 text-body2',
     lg: 'px-6 py-3 text-body1',
+    xl: 'px-8 py-4 text-lg',
   };
 
   const widthClasses = fullWidth ? 'w-full' : '';


### PR DESCRIPTION
Add 'xl' size option to Button component to support a larger button size.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-1f0ac9eb-6213-420d-91ff-5515d76f6829) · [Cursor](https://cursor.com/background-agent?bcId=bc-1f0ac9eb-6213-420d-91ff-5515d76f6829)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)