### PR TITLE
Publish assets to gh-pages with force push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     
     steps:
     - name: Checkout


### PR DESCRIPTION
```
Add explicit permissions to the GitHub Pages deployment workflow to resolve 403 permission error.
```

---

[Open in Web](https://www.cursor.com/agents?id=bc-39dd138c-91a1-4c9e-bc77-7ab3b947a9c2) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-39dd138c-91a1-4c9e-bc77-7ab3b947a9c2)